### PR TITLE
[modular] single line removal bugfix for polybelt

### DIFF
--- a/code/modules/clothing/belts/polymorph_belt.dm
+++ b/code/modules/clothing/belts/polymorph_belt.dm
@@ -45,7 +45,9 @@
 	qdel(weapon)
 	active = TRUE
 	update_appearance(UPDATE_ICON_STATE)
-	update_transform_action()
+	/// NOVA EDIT REMOVE START (fix issue with polymorph belt making your spritesize 1 upon scanning a mob/touching the belt after a mob is scanned on it)
+	/// update_transform_action()
+	/// NOVA EDIT REMOVE END
 	playsound(src, 'sound/machines/crate/crate_open.ogg', 50, FALSE)
 
 /obj/item/polymorph_belt/attack(mob/living/target_mob, mob/living/user, params)


### PR DESCRIPTION

## About The Pull Request
removes a single update_transform_action() from the polymorph_belt.dm
## How This Contributes To The Nova Sector Roleplay Experience
this is a bug
## Proof of Testing
<details>
<summary>Screenshots/Videos</summary>
  before:
  https://cdn.discordapp.com/attachments/1172988592658841680/1353471650129248396/20250323-2052-33.3423139.mp4?ex=67e1c633&is=67e074b3&hm=c30cb2df65445fa608ed195c37f0b290fa5cf9b95529e86739833da0fe8d30d3&
  after:
  https://cdn.discordapp.com/attachments/1172988592658841680/1353491314343415849/20250323-2210-36.2792970.mp4?ex=67e1d883&is=67e08703&hm=d16c33aedc31fbfbcf668ebdbcd94c2395aa01a97bc7290c61c7dedc59dcaa5f&
</details>

## Changelog
:cl:
fix: polymorph belt no longer messes with your sprite when scanning a creature
/:cl:
